### PR TITLE
Show run's full display name in PromotedBuildParameterValue

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue/value.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue/value.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 	<f:entry title="${it.name}" description="${it.description}">
         <div name="parameter">
-            <a href="${rootURL}/${it.run.url}">${it.run}</a>
+            <a href="${rootURL}/${it.run.url}">${it.run.fullDisplayName}</a>
             <input type="hidden" name="name" value="${it.name}" />
             <input type="hidden" name="runId" value="${it.run.externalizableId}" />
         </div>


### PR DESCRIPTION
Hi @alhafoudh, I just noticed one other place while reviewing your PR that we should update for consistency. If it looks good to you and you merge it into your PR then I will go ahead and merge+release upstream.

Thanks!